### PR TITLE
Add printModelGeometry command

### DIFF
--- a/OpenSeesComposite.tcl
+++ b/OpenSeesComposite.tcl
@@ -18,5 +18,6 @@ namespace eval OpenSeesComposite {
 
     # Export Miscellaneous Commands
     namespace export \
-        wShapeLookup eigenRecorder updateRayleighDamping printNodeCoordinates
+        wShapeLookup eigenRecorder updateRayleighDamping printNodeCoordinates \
+        printModelGeometry
 }


### PR DESCRIPTION
Add `printModelGeometry`, which prints the node coordinates and element linkages of the model in JSON format to stdout or a file. This allows us to bypass patching OpenSees's `print` command for every element, section, material, etc., when all we (currently) care about getting output for is the geometry.

A dependency is added for the [standard Tcl library](https://www.tcl.tk/software/tcllib) package `json::write`. I think most Tcl distributions come with tcllib, but it's possible for them not to.