### PR TITLE
Fix using matTag directly

### DIFF
--- a/wSections.tcl
+++ b/wSections.tcl
@@ -225,7 +225,7 @@ proc OpenSeesComposite::wfSection { secID nf1 nf2 d tw bf tf args} {
     lappend materialParams $elb
   }
 
-  if { $residualStressType == "null" } {
+  if { $residualStressType == "null" && $materialType != "matTag" } {
     eval defineUniaxialMaterialWithResidualStress $currentMatTag 0.0 $materialType $materialParams
     set materialType matTag
   }


### PR DESCRIPTION
If a section was defined using `-matTag $tag` it would try to call `defineUniaxialMaterialWithResidualStress` to define a material called `matTag` and then error out.